### PR TITLE
fix: change name of sandbox extension to Developer Sandbox

### DIFF
--- a/api/extensions.json
+++ b/api/extensions.json
@@ -140,8 +140,8 @@
         "displayName": "Red Hat"
       },
       "extensionName": "redhat-sandbox",
-      "displayName": "Red Hat OpenShift Sandbox",
-      "shortDescription": "OpenShift Sandbox sign up and provisioning",
+      "displayName": "Developer Sandbox",
+      "shortDescription": "Developer Sandbox sign up and provisioning",
       "license": "Apache-2.0",
       "categories": ["Kubernetes"],
       "keywords": ["redhat", "sandbox", "provider", "remote"],


### PR DESCRIPTION
Related to https://github.com/redhat-developer/podman-desktop-sandbox-ext/issues/278.