### PR TITLE
fix(extension-quadlet): make extension name match

### DIFF
--- a/static/api/extensions.json
+++ b/static/api/extensions.json
@@ -1173,7 +1173,7 @@
         "publisherName": "podman-desktop",
         "displayName": "Podman Desktop"
       },
-      "extensionName": "podman-quadlet",
+      "extensionName": "quadlet",
       "displayName": "Podman Quadlet",
       "shortDescription": "Integrate Podman Quadlets in Podman Desktop",
       "license": "Apache-2.0",


### PR DESCRIPTION
Following https://github.com/podman-desktop/podman-desktop-catalog/pull/231

I made  mistake, I used `Podman Quadlet` as extension name.

But it must match the name from the `packages/backend/package.json` of the extension which is `quadlet`.

This lead to the following problem

![image](https://github.com/user-attachments/assets/3a54774f-e8cf-4391-a795-c3d3878883b4)

It does not show as installed.