### PR TITLE
chore: fix duplicated entry in lock file

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6390,11 +6390,6 @@ snapshots:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
 
-  tinyglobby@0.2.13:
-    dependencies:
-      fdir: 6.4.4(picomatch@4.0.2)
-      picomatch: 4.0.2
-
   tinypool@1.0.2: {}
 
   tinyrainbow@2.0.0: {}


### PR DESCRIPTION
Merging PRs with Dependabot results in a duplicate entry in the lock file

Change-Id: I2b99d6af24ae476a1bfd517499e7254c31ba5c69