### PR TITLE
chore: postgresql v0.4.0

### DIFF
--- a/static/api/extensions.json
+++ b/static/api/extensions.json
@@ -1846,6 +1846,27 @@
       "keywords": ["database", "connection", "discover"],
       "versions": [
         {
+          "version": "0.4.0",
+          "podmanDesktopVersion": "^1.16.0",
+          "preview": false,
+          "lastUpdated": "2025-10-27T08:00:00Z",
+          "ociUri": "ghcr.io/podman-desktop/extension-postgresql:0.4.0",
+          "files": [
+            {
+              "assetType": "icon",
+              "data": "https://registry.podman-desktop.io/api/extensions/podman-desktop/postgresql/0.4.0/icon.png"
+            },
+            {
+              "assetType": "README",
+              "data": "https://registry.podman-desktop.io/api/extensions/podman-desktop/postgresql/0.4.0/README.md"
+            },
+            {
+              "assetType": "LICENSE",
+              "data": "https://registry.podman-desktop.io/api/extensions/podman-desktop/postgresql/0.4.0/LICENSE"
+            }
+          ]
+        },
+        {
           "version": "0.3.0",
           "podmanDesktopVersion": "^1.16.0",
           "preview": false,


### PR DESCRIPTION
- adds postgres icon to the image, to make it displayed correctly in the list of containers for containers using postgres image
- update the publisher name in the package.json of the image, to mark the extension as "already installed" in the catalog page when installed

(https://github.com/podman-desktop/extension-postgresql/releases/tag/v0.4.0)