### PR TITLE
chore: add tailwindcss in css parser options for Biome

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -22,6 +22,9 @@
     }
   },
   "css": {
+    "parser": {
+      "tailwindDirectives": true
+    },
     "formatter": {
       "quoteStyle": "single"
     }


### PR DESCRIPTION
Biome v2.3 says that there is an opt-in feature for Tailwindcss but if the flag is not here, you've an error saying you need to take a decision about tailwindcss
https://biomejs.dev/blog/biome-v2-3/#tailwind-v4-support

add the flag

fixes https://github.com/podman-desktop/podman-desktop-catalog/pull/841

Change-Id: I39b6882bd395fa8f719cf9a7a8a26cf60fbd6da6