### PR TITLE
fix: resolve CVE-2026-33671 in picomatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
       "flatted@^3": "^3.4.2",
       "minimatch@^3": "^3.1.5",
       "minimatch@^9": "^9.0.9",
-      "minimatch@^10": "^10.2.4"
+      "minimatch@^10": "^10.2.4",
+      "picomatch@>=4.0.0": ">=4.0.4"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   minimatch@^3: ^3.1.5
   minimatch@^9: ^9.0.9
   minimatch@^10: ^10.2.4
+  picomatch@>=4.0.0: '>=4.0.4'
 
 importers:
 
@@ -1836,7 +1837,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2519,10 +2520,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -5584,8 +5581,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pluralize@8.0.0: {}
@@ -6144,7 +6139,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-33671 in `picomatch`.

**Advisory**: Picomatch has a ReDoS vulnerability via extglob quantifiers
**Vulnerable versions**: >=4.0.0 <4.0.4
**Patched versions**: >=4.0.4
**Advisory URL**: https://github.com/advisories/GHSA-c2c7-rcm5-vvqj

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-33671: _Picomatch has a ReDoS vulnerability via extglob quantifiers_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-33671 is no longer reported