### PR TITLE
fix(catalog): update Podman links to new GitHub org

### DIFF
--- a/static/api/extensions/redhat/ai-lab/0.4.0/README.md
+++ b/static/api/extensions/redhat/ai-lab/0.4.0/README.md
@@ -53,7 +53,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.0.0/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.0.0/README.md
@@ -53,7 +53,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.1.1/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.1.1/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.1.2/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.1.2/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.2.3/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.2.3/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.3.1/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.3.1/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.3.2/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.3.2/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.3.4/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.3.4/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.4.0/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.4.0/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.5.0/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.5.0/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.6.1/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.6.1/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.7.2/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.7.2/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.8.0/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.8.0/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.9.1/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.9.1/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.9.1+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.9.2/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.9.2/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/1.9.3/README.md
+++ b/static/api/extensions/redhat/ai-lab/1.9.3/README.md
@@ -50,7 +50,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/ai-lab/preview/README.md
+++ b/static/api/extensions/redhat/ai-lab/preview/README.md
@@ -53,7 +53,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-- [Podman 4.9.0+](https://github.com/containers/podman)
+- [Podman 4.9.0+](https://github.com/podman-container-tools/podman)
 
 **Hardware**
 

--- a/static/api/extensions/redhat/bootc/0.1.0/README.md
+++ b/static/api/extensions/redhat/bootc/0.1.0/README.md
@@ -42,7 +42,7 @@ Disclaimer: This is **EXPERIMENTAL** and all features are subject to change as w
 ### Requirement 1. System requirements
 
 * macOS M1/M2/M3 Silicon Architecture ONLY (Windows & Linux support coming soon)
-* [podman 4.9.0+](https://github.com/containers/podman/releases/tag/v4.9.0)
+* [podman 4.9.0+](https://github.com/podman-container-tools/podman/releases/tag/v4.9.0)
 * [vfkit 0.5.1+](https://github.com/crc-org/vfkit) for "one-click" VM launch button support
 
 ### Requirement 2. Rootful mode on Podman Machine

--- a/static/api/extensions/redhat/bootc/0.2.0/README.md
+++ b/static/api/extensions/redhat/bootc/0.2.0/README.md
@@ -85,7 +85,7 @@ Note: Windows & Linux not supported, but coming soon
 
 **Software:**
 * [Podman Desktop 1.7.0+](https://github.com/containers/podman-desktop)
-* [Podman 4.9.0+](https://github.com/containers/podman) (should be automatically installed by Podman Desktop already)
+* [Podman 4.9.0+](https://github.com/podman-container-tools/podman) (should be automatically installed by Podman Desktop already)
 
 ### Requirement 2. Rootful mode on Podman Machine
 

--- a/static/api/extensions/redhat/bootc/0.3.0/README.md
+++ b/static/api/extensions/redhat/bootc/0.3.0/README.md
@@ -85,7 +85,7 @@ Note: Windows & Linux not supported, but coming soon
 
 **Software:**
 * [Podman Desktop 1.7.0+](https://github.com/containers/podman-desktop)
-* [Podman 4.9.0+](https://github.com/containers/podman) (should be automatically installed by Podman Desktop already)
+* [Podman 4.9.0+](https://github.com/podman-container-tools/podman) (should be automatically installed by Podman Desktop already)
 
 ### Requirement 2. Rootful mode on Podman Machine
 

--- a/static/api/extensions/redhat/bootc/0.4.0/README.md
+++ b/static/api/extensions/redhat/bootc/0.4.0/README.md
@@ -84,7 +84,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.0+](https://github.com/containers/podman)
+* [Podman 5.0.0+](https://github.com/podman-container-tools/podman)
 
 ### Requirement 2. Rootful mode on Podman Machine
 

--- a/static/api/extensions/redhat/bootc/0.5.0/README.md
+++ b/static/api/extensions/redhat/bootc/0.5.0/README.md
@@ -90,7 +90,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.8.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.0+](https://github.com/containers/podman)
+* [Podman 5.0.0+](https://github.com/podman-container-tools/podman)
 
 ### Requirement 2. Rootful mode on Podman Machine
 

--- a/static/api/extensions/redhat/bootc/1.0.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.0.0/README.md
@@ -98,7 +98,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.1+](https://github.com/containers/podman)
+* [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Requirement 2. Rootful mode on Podman Machine
 

--- a/static/api/extensions/redhat/bootc/1.1.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.1.0/README.md
@@ -120,7 +120,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.1+](https://github.com/containers/podman)
+* [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Requirement 2. Rootful mode on Podman Machine
 

--- a/static/api/extensions/redhat/bootc/1.10.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.10.0/README.md
@@ -110,7 +110,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-- [Podman 5.0.1+](https://github.com/containers/podman)
+- [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.11.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.11.0/README.md
@@ -112,7 +112,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-- [Podman 5.0.1+](https://github.com/containers/podman)
+- [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.12.2/README.md
+++ b/static/api/extensions/redhat/bootc/1.12.2/README.md
@@ -112,7 +112,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.10.0+](https://github.com/podman-desktop/podman-desktop)
-- [Podman 5.0.1+](https://github.com/containers/podman)
+- [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.13.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.13.0/README.md
@@ -112,7 +112,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.10.0+](https://github.com/podman-desktop/podman-desktop)
-- [Podman 5.0.1+](https://github.com/containers/podman)
+- [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.14.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.14.0/README.md
@@ -112,7 +112,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.10.0+](https://github.com/podman-desktop/podman-desktop)
-- [Podman 5.0.1+](https://github.com/containers/podman)
+- [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.2.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.2.0/README.md
@@ -124,7 +124,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.1+](https://github.com/containers/podman)
+* [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Requirement 2. Rootful mode on Podman Machine
 

--- a/static/api/extensions/redhat/bootc/1.3.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.3.0/README.md
@@ -124,7 +124,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.1+](https://github.com/containers/podman)
+* [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.4.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.4.0/README.md
@@ -124,7 +124,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.1+](https://github.com/containers/podman)
+* [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.5.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.5.0/README.md
@@ -126,7 +126,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.1+](https://github.com/containers/podman)
+* [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.6.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.6.0/README.md
@@ -126,7 +126,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.1+](https://github.com/containers/podman)
+* [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.6.1/README.md
+++ b/static/api/extensions/redhat/bootc/1.6.1/README.md
@@ -126,7 +126,7 @@ Compatible on Windows, macOS & Linux
 
 **Software:**
 * [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-* [Podman 5.0.1+](https://github.com/containers/podman)
+* [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.7.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.7.0/README.md
@@ -127,7 +127,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-- [Podman 5.0.1+](https://github.com/containers/podman)
+- [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.8.0/README.md
+++ b/static/api/extensions/redhat/bootc/1.8.0/README.md
@@ -133,7 +133,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-- [Podman 5.0.1+](https://github.com/containers/podman)
+- [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/1.9.1/README.md
+++ b/static/api/extensions/redhat/bootc/1.9.1/README.md
@@ -133,7 +133,7 @@ Compatible on Windows, macOS & Linux
 **Software:**
 
 - [Podman Desktop 1.10.0+](https://github.com/containers/podman-desktop)
-- [Podman 5.0.1+](https://github.com/containers/podman)
+- [Podman 5.0.1+](https://github.com/podman-container-tools/podman)
 
 ### Podman Machine (macOS / Windows)
 

--- a/static/api/extensions/redhat/bootc/preview/README.md
+++ b/static/api/extensions/redhat/bootc/preview/README.md
@@ -42,7 +42,7 @@ Disclaimer: This is **EXPERIMENTAL** and all features are subject to change as w
 ### Requirement 1. System requirements
 
 * macOS M1/M2/M3 Silicon Architecture ONLY (Windows & Linux support coming soon)
-* [podman 4.9.0+](https://github.com/containers/podman/releases/tag/v4.9.0)
+* [podman 4.9.0+](https://github.com/podman-container-tools/podman/releases/tag/v4.9.0)
 * [vfkit 0.5.1+](https://github.com/crc-org/vfkit) for "one-click" VM launch button support
 
 ### Requirement 2. Rootful mode on Podman Machine


### PR DESCRIPTION
## Summary

- update archived extension README snapshots under `static/api/extensions/redhat/{ai-lab,bootc}`
- switch Podman links from `containers/podman` to `podman-container-tools/podman`

## Upstream PRs (merge before this one)

This catalog change mirrors README updates from the upstream extension repositories. Merge these PRs first:

- [ ] [containers/podman-desktop-extension-ai-lab#4541](https://github.com/containers/podman-desktop-extension-ai-lab/pull/4541) — fix(docs): update Podman repository link
- [ ] [podman-desktop/extension-bootc#2585](https://github.com/podman-desktop/extension-bootc/pull/2585) — fix(docs): update Podman repository link

## Test plan

- [ ] Run `rg "https://github.com/containers/podman([^A-Za-z0-9_-]|$)" static/api/extensions/redhat` and confirm no matches
- [ ] Confirm all upstream PRs above are merged

Made with [Cursor](https://cursor.com)