### PR TITLE
fix: resolve CVE-2026-9697 in undici 

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
       "brace-expansion@^1": "^1.1.13",
       "postcss": "^8.5.12",
       "esbuild": ">=0.28.1",
-      "js-yaml": ">=4.2.0"
+      "js-yaml": ">=4.2.0",
+      "undici": "^7.28.0"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   postcss: ^8.5.12
   esbuild: '>=0.28.1'
   js-yaml: '>=4.2.0'
+  undici: ^7.28.0
 
 importers:
 
@@ -2814,8 +2815,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unrs-resolver@1.12.2:
@@ -4948,7 +4949,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5816,7 +5817,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-9697 in `undici`.

**Advisory**: undici vulnerable to TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent
**Vulnerable versions**: >=7.23.0 <7.28.0
**Patched versions**: >=7.28.0
**Advisory URL**: https://github.com/advisories/GHSA-vmh5-mc38-953g

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-9697: _undici vulnerable to TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-9697 is no longer reported