### PR TITLE
chore(pnpm): bump to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-node-linker=hoisted
-

--- a/package.json
+++ b/package.json
@@ -65,22 +65,5 @@
     "vitest": "^4.1.0"
   },
   "type": "module",
-  "pnpm": {
-    "overrides": {
-      "@sveltejs/kit>cookie": "^0.7.0",
-      "flatted@^3": "^3.4.2",
-      "minimatch@^3": "^3.1.5",
-      "minimatch@^9": "^9.0.9",
-      "minimatch@^10": "^10.2.4",
-      "picomatch@>=4.0.0": ">=4.0.4",
-      "brace-expansion@^1": "^1.1.17",
-      "brace-expansion@^2": "^2.1.4",
-      "brace-expansion@^5": "^5.0.9",
-      "postcss": ">=8.5.18",
-      "esbuild": ">=0.28.1",
-      "js-yaml": ">=4.2.0",
-      "undici": "^7.28.0"
-    }
-  },
-  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
+  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,17 @@
+overrides:
+  '@sveltejs/kit>cookie': ^0.7.0
+  flatted@^3: ^3.4.2
+  minimatch@^3: ^3.1.5
+  minimatch@^9: ^9.0.9
+  minimatch@^10: ^10.2.4
+  picomatch@>=4.0.0: '>=4.0.4'
+  brace-expansion@^1: ^1.1.17
+  brace-expansion@^2: ^2.1.4
+  brace-expansion@^5: ^5.0.9
+  postcss: '>=8.5.18'
+  esbuild: '>=0.28.1'
+  js-yaml: '>=4.2.0'
+  undici: ^7.28.0
+nodeLinker: hoisted
+allowBuilds:
+  unrs-resolver: true


### PR DESCRIPTION
### What does this PR do?

Bumping pnpm to v11. I ran the migration script provided `pnpx codemod run pnpm-v10-to-v11`[^1]

[^1]: https://pnpm.io/migration

### What issues does this PR fix or reference?

Same as https://github.com/podman-desktop/podman-desktop/issues/17794

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be :green_circle: 
