### PR TITLE
fix: resolve GHSA-pm4m-ph32-ghv5 in js-yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,8 @@ overrides:
   brace-expansion@^5: ^5.0.9
   postcss: '>=8.5.18'
   esbuild: '>=0.28.1'
-  js-yaml: '>=4.2.0'
+  js-yaml@^4: ^4.3.1
+  js-yaml@^5: ^5.3.0
   undici: ^7.28.0
 
 importers:
@@ -2030,8 +2031,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -3296,7 +3297,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5029,7 +5030,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,8 @@ overrides:
   brace-expansion@^5: ^5.0.9
   postcss: '>=8.5.18'
   esbuild: '>=0.28.1'
-  js-yaml: '>=4.2.0'
+  js-yaml@^4: ^4.3.1
+  js-yaml@^5: ^5.3.0
   undici: ^7.28.0
 nodeLinker: hoisted
 allowBuilds:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-pm4m-ph32-ghv5 in `js-yaml`.

**Advisory**: js-yaml: Exponential parsing time in flow collections leads to denial of service
**Vulnerable versions**: >=5.0.0 <=5.2.1
**Patched versions**: >=5.2.2
**Advisory URL**: https://github.com/advisories/GHSA-pm4m-ph32-ghv5

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-pm4m-ph32-ghv5: _js-yaml: Exponential parsing time in flow collections leads to denial of service_

### How to test this PR?

Run `pnpm audit` and verify GHSA-pm4m-ph32-ghv5 is no longer reported